### PR TITLE
Fix "AttributeError: module 'sympy' has no attribute 'power'"

### DIFF
--- a/src/pytuning/constants.py
+++ b/src/pytuning/constants.py
@@ -29,9 +29,14 @@ five_limit_constructors = [
     (sp.Rational(9,8),   "T"),
 ]
 
+try:
+    power = sp.power
+except AttributeError:
+    power = sp
+
 edo12_constructors = [
-    (sp.power.Pow(2,sp.Rational(2,12)), "T"),
-    (sp.power.Pow(2,sp.Rational(1,12)), "s"),
+    (power.Pow(2,sp.Rational(2,12)), "T"),
+    (power.Pow(2,sp.Rational(1,12)), "s"),
 ]
 
 lucy_L = sp.root(2,2*sp.pi)


### PR DESCRIPTION
I don't know how it works, but its works fine.

for backward compatibility, wrapped by try-exception block.

fixes https://github.com/MarkCWirt/PyTuning/issues/3